### PR TITLE
removed on_error() method

### DIFF
--- a/lib/Mojo/Redis.pm
+++ b/lib/Mojo/Redis.pm
@@ -189,7 +189,7 @@ sub subscribe {
           my ($str, $error) = @_;
           $self->error($error);
 
-          $self->on_error->($self);
+          $self->emit(error => $error);
           $self->ioloop->remove($id);
         }
       );
@@ -330,13 +330,6 @@ sub _inform_queue {
 
   $self->{_queue} = [];
 }
-
-# avoid pod test
-*on_error = sub {
-    my $self = shift;
-    warn "on_error() is deprecated! use on(error => sub {}) instead";
-    $self->on(error => shift);
-};
 
 1;
 __END__

--- a/t/leak.t
+++ b/t/leak.t
@@ -20,7 +20,7 @@ plan tests => 4;
 
 my $redis = Mojo::Redis->new(server => $ENV{REDIS_SERVER}, timeout => 5);
 
-$redis->on_error(sub { });
+$redis->on(error => sub {});
 
 no_leaks_ok {
     $redis->ping(\&cb_ioloop_stop)->ioloop->start;


### PR DESCRIPTION
t/pubsub_live.t fail now. Looks like it's "random" as well:
# mojo-redis

redis 127.0.0.1:6379> monitor
1345576288.157469 "PUBLISH" "bar" "once mo"
1345576288.157552 "SUBSCRIBE" "foo" "bar"

^ Publish before subscribe? This only happens some times as well...
