### PR TITLE
Callbacks will receive HGETALL result as hash-ref from both ececute(...) and hgetall().

### DIFF
--- a/lib/Mojo/Redis.pm
+++ b/lib/Mojo/Redis.pm
@@ -229,17 +229,14 @@ sub execute {
   my $mqueue = $self->{_message_queue} ||= [];
   my $cqueue = $self->{_cb_queue}      ||= [];
 
-  if($cb and 1 < @commands) {
-    my(@res, $n);
+  if($cb) {
+    my @res;
     my $process = sub {
-      push @res, $_[1];
-      $_[0]->$cb(@res) unless --$n;
+      my $command = shift @commands;
+      push @res, $command->[0] eq 'HGETALL' ? { @{ $_[1] } } : $_[1];
+      $_[0]->$cb(@res) unless @commands;
     };
-    $n = @commands;
-    push @$cqueue, ($process) x $n;
-  }
-  elsif($cb) {
-    push @$cqueue, $cb;
+    push @$cqueue, ($process) x int @commands;
   }
   else {
     push @$cqueue, sub {};

--- a/t/redis_live_multi.t
+++ b/t/redis_live_multi.t
@@ -26,4 +26,4 @@ $redis->del('test')->multi->rpush(test => 'ok')->lrange(test => 0, -1)->exec(
     }
 )->ioloop->start;
 
-is_deeply $result, [1, ['ok']];
+is_deeply $result, [1, ['ok']], 'got lrange result';


### PR DESCRIPTION
It's quite annoying to do $res = { @$res }; all the time.
