### PR TITLE
Bad bug when not specifying callback

### DIFF
--- a/lib/Mojo/Redis.pm
+++ b/lib/Mojo/Redis.pm
@@ -239,7 +239,7 @@ sub execute {
     push @$cqueue, ($process) x int @commands;
   }
   else {
-    push @$cqueue, sub {};
+    push @$cqueue, (sub {}) x int @commands;
   }
 
   push @$mqueue, @commands;

--- a/t/redis_live.t
+++ b/t/redis_live.t
@@ -82,6 +82,9 @@ $redis->execute(
     }
 );
 
+$redis->del('test') for 1..5;
+$redis->execute(set => test => 1) for 1..5;
+$redis->execute([set => test => 1], [set => test => 1]) for 1..3;
 $redis->set(test => 'ok')->get(
     test => sub {
         is $_[1], 'ok', "Fast command check";


### PR DESCRIPTION
This
    $redis->execute(\@first, \@second);
    followed by
    $redis->set(@foo, $cb);
    will call $cb with the result from @first (or @second)
