### PR TITLE
Add eval() and fixed unlisten()

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -1,1 +1,0 @@
-lib/Mojo/Redis.pm

--- a/cpanfile
+++ b/cpanfile
@@ -3,3 +3,4 @@ requires "Mojolicious"     => "7.30";
 requires "Protocol::Redis" => "1.0006";
 
 test_requires "Test::More" => "0.88";
+test_requires "Test::Memory::Cycle";

--- a/lib/Mojo/Redis/Database.pm
+++ b/lib/Mojo/Redis/Database.pm
@@ -16,7 +16,8 @@ our @BASIC_OPERATIONS = (
   'spop',             'srandmember', 'srem',             'strlen',   'sunion',   'sunionstore',
   'ttl',              'type',        'zadd',             'zcard',    'zcount',   'zincrby',
   'zinterstore',      'zrange',      'zrangebyscore',    'zrank',    'zrem',     'zremrangebyrank',
-  'zremrangebyscore', 'zrevrange',   'zrevrangebyscore', 'zrevrank', 'zscore',   'zunionstore'
+  'zremrangebyscore', 'zrevrange',   'zrevrangebyscore', 'zrevrank', 'zscore',   'zunionstore',
+  'eval'
 );
 
 has connection => sub { Carp::confess('connection is not set') };

--- a/lib/Mojo/Redis/PubSub.pm
+++ b/lib/Mojo/Redis/PubSub.pm
@@ -29,7 +29,7 @@ sub notify {
 sub unlisten {
   my ($self, $name, $cb) = @_;
   my $chan = $self->{chans}{$name};
-  my $op = $name =~ /\*/ ? 'PSUBSCRIBE' : 'SUBSCRIBE';
+  my $op = $name =~ /\*/ ? 'PUNSUBSCRIBE' : 'UNSUBSCRIBE';
 
   @$chan = $cb ? grep { $cb ne $_ } @$chan : ();
   $self->connection->write($op => $name) and delete $self->{chans}{$name} unless @$chan;

--- a/t/db.t
+++ b/t/db.t
@@ -26,6 +26,12 @@ is_deeply \@res, ['', '123'], 'get';
 # DEL
 $db->del($0 => sub { @res = @_[1, 2]; Mojo::IOLoop->stop });
 Mojo::IOLoop->start;
-is_deeply \@res, ['', 1], 'get';
+is_deeply \@res, ['', 1], 'del';
+
+# EVAL
+my $lua_script = 'return(KEYS[1])';
+$db->eval($lua_script, 1, key1 => sub { @res = @_[1, 2]; Mojo::IOLoop->stop });
+Mojo::IOLoop->start;
+is_deeply \@res, ['','key1'], 'eval';
 
 done_testing;


### PR DESCRIPTION
Would be nice to have EVAL function on the module, so we can do basic lua scripting.

Lua scripting is important for atomic operations, as suggested in https://redis.io/topics/transactions